### PR TITLE
Allow creation of both udp4/udp6 socket types.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const readFile = util.promisify(fs.readFile);
 const TFTPServer = require('./tftp-server.js');
 
 module.exports.TFTPServer = TFTPServer;
-module.exports.createServer = () => new TFTPServer();
+module.exports.createServer = (socketType = 'udp6') => new TFTPServer(socketType);
 module.exports.serveStatic = (dir) => (req, res, next) => {
 	readFile(path.join(dir, req.filename))
 		.then((data) => res(data))

--- a/tftp-server.js
+++ b/tftp-server.js
@@ -4,8 +4,8 @@ const EventEmitter = require('events').EventEmitter;
 const util = require('util');
 const debug = util.debuglog('tftp');
 
-function TFTPServer () {
-	this.socket = dgram.createSocket('udp6');
+function TFTPServer (socketType) {
+	this.socket = dgram.createSocket(socketType);
 	this.routes = [];
 	this.connections = {};
 	this.ingress = new EventEmitter();


### PR DESCRIPTION
I was having issues with the default 'udp6' socket type of this library so I created this patch to allow the creation of 'udp4' socket type while keeping backwards compatibility.